### PR TITLE
Add ApplyTemplate for visual elements

### DIFF
--- a/ext/MouseKeyboardActivityMonitor/MouseKeyboardActivityMonitor.csproj
+++ b/ext/MouseKeyboardActivityMonitor/MouseKeyboardActivityMonitor.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
     <ProductVersion>9.0.21022</ProductVersion>
@@ -29,7 +29,7 @@
     </UpgradeBackupLocation>
     <IsWebBootstrapper>true</IsWebBootstrapper>
     <OldToolsVersion>3.5</OldToolsVersion>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -48,6 +48,7 @@
     <ApplicationVersion>2.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>bin\Debug\</OutputPath>
@@ -71,6 +72,7 @@
     <DebugType>full</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <OutputPath>bin\Release\</OutputPath>
@@ -94,6 +96,7 @@
     <DebugType>none</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -114,6 +117,7 @@
     <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
@@ -133,6 +137,7 @@
     <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -154,6 +159,7 @@
     <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -173,6 +179,7 @@
     <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System">

--- a/src/MoonPdfLib/Helper/VisualTreeHelperEx.cs
+++ b/src/MoonPdfLib/Helper/VisualTreeHelperEx.cs
@@ -30,7 +30,12 @@ namespace MoonPdfLib.Helper
 			if (o is T)
 				return (T)o;
 
-			for (int i = 0; i < VisualTreeHelper.GetChildrenCount(o); i++)
+            if (o is FrameworkElement)
+            {
+                (o as FrameworkElement).ApplyTemplate();
+            }
+
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(o); i++)
 			{
 				var child = VisualTreeHelper.GetChild(o, i);
 				var result = FindChild<T>(child);

--- a/src/MoonPdfLib/MoonPdfLib.csproj
+++ b/src/MoonPdfLib/MoonPdfLib.csproj
@@ -145,12 +145,12 @@
     <None Include="headertemplate.json" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
+  <!--<PropertyGroup>
     <PostBuildEvent>xcopy $(SolutionDir)..\bin\MuLib\$(PlatformName)\libmupdf.dll $(TargetDir) /Y</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>$(SolutionDir)..\bin\HeaderLicensePrepend\HeaderLicensePrepend.exe $(ProjectDir)headertemplate.json</PreBuildEvent>
-  </PropertyGroup>
+  </PropertyGroup>-->
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/MoonPdfLib/MoonPdfPanel.xaml.cs
+++ b/src/MoonPdfLib/MoonPdfPanel.xaml.cs
@@ -70,8 +70,11 @@ namespace MoonPdfLib
 
 		public static readonly DependencyProperty PageRowDisplayProperty = DependencyProperty.Register("PageRowDisplay", typeof(PageRowDisplayType),
 																			typeof(MoonPdfPanel), new FrameworkPropertyMetadata(PageRowDisplayType.SinglePageRow));
-		
-		public Thickness PageMargin
+
+        public static readonly DependencyProperty PdfFilePathProperty = DependencyProperty.RegisterAttached("PdfFilePath", typeof(string),
+                                                                            typeof(MoonPdfPanel), new PropertyMetadata(""));
+
+        public Thickness PageMargin
 		{
 			get { return (Thickness)GetValue(PageMarginProperty); }
 			set { SetValue(PageMarginProperty, value); }
@@ -112,9 +115,15 @@ namespace MoonPdfLib
 			get { return (PageRowDisplayType)GetValue(PageRowDisplayProperty); }
 			set { SetValue(PageRowDisplayProperty, value); }
 		}
-		#endregion
 
-		public double HorizontalMargin { get { return this.PageMargin.Right; } }
+        public string PdfFilePath
+        {
+            get { return (string)GetValue(PdfFilePathProperty); }
+            set { SetValue(PdfFilePathProperty, value); }
+        }
+        #endregion
+
+        public double HorizontalMargin { get { return this.PageMargin.Right; } }
         public IPdfSource CurrentSource { get; private set; }
         public string CurrentPassword { get; private set; }
 		public int TotalPages { get; private set; }
@@ -379,7 +388,9 @@ namespace MoonPdfLib
 				this.Rotate((ImageRotation)e.NewValue);
 			else if (e.Property.Name.Equals("ViewType"))
 				this.ApplyChangedViewType((ViewType)e.OldValue);
-		}
+            else if (e.Property.Name.Equals("PdfFilePath"))
+                this.OpenFile((string)e.NewValue);
+        }
 
 		private void ApplyChangedViewType(ViewType oldViewType)
 		{


### PR DESCRIPTION
I have had problems in building a "content viewer" where I load MoonPdfPanel in runtime. [Neither ScrollViewer nor VirtualPanel](https://github.com/reliak/moonpdf/blob/master/src/MoonPdfLib/ContinuousMoonPdfPanel.xaml.cs#L63-L64) would be found during Load() function because the UserControl depends on [templates](https://github.com/reliak/moonpdf/blob/master/src/MoonPdfLib/ContinuousMoonPdfPanel.xaml#L18-L24). These templates must be applied before they can be found by the VisualTreeHelper.



Since there are not tests I can not add/write any.